### PR TITLE
Try to use 16x16 in icon file if possible.

### DIFF
--- a/KeePassFaviconDownloaderExt.cs
+++ b/KeePassFaviconDownloaderExt.cs
@@ -500,7 +500,12 @@ namespace KeePassFaviconDownloader
                 
                 // END change
 
-                try { img = (new Icon(memStream)).ToBitmap(); }
+                try
+                {
+                    Icon icon = new Icon(memStream);
+                    icon = new Icon(icon, 16, 16);
+                    img = icon.ToBitmap();
+                }
                 catch (Exception)
                 {
                     // This shouldn't be useful unless someone has messed up their favicon format


### PR DESCRIPTION
The current method causes unnecessary downscaling when there is a 16x16 icon available in addition to other sizes. This patch tries to use the 16x16 icon if available.
