### PR TITLE
Higher quality scaling.

### DIFF
--- a/KeePassFaviconDownloaderExt.cs
+++ b/KeePassFaviconDownloaderExt.cs
@@ -528,8 +528,16 @@ namespace KeePassFaviconDownloader
 
             try
             {
-                Image imgNew = new Bitmap(img, new Size(16, 16));
-
+                Bitmap imgNew = new Bitmap(16, 16);
+                imgNew.SetResolution(img.HorizontalResolution, img.VerticalResolution);
+                using (Graphics g = Graphics.FromImage(imgNew))
+                {
+                    // set the resize quality modes to high quality
+                    g.CompositingQuality = System.Drawing.Drawing2D.CompositingQuality.HighQuality;
+                    g.InterpolationMode = System.Drawing.Drawing2D.InterpolationMode.HighQualityBicubic;
+                    g.SmoothingMode = System.Drawing.Drawing2D.SmoothingMode.HighQuality;
+                    g.DrawImage(img, 0, 0, imgNew.Width, imgNew.Height);
+                }
                 ms = new MemoryStream();
                 imgNew.Save(ms, System.Drawing.Imaging.ImageFormat.Png);
                 return true;


### PR DESCRIPTION
The default scaling settings are too crude. Compare (for reddit.com):

before: ![before](https://f.cloud.github.com/assets/1037172/1643492/ec635f72-58c8-11e3-9b17-cb8197c0e0ff.png)
after: ![after](https://f.cloud.github.com/assets/1037172/1643493/ec63aa04-58c8-11e3-95d8-e1860304c118.png)
