### PR TITLE
Add CookieContainer before retrieving URL

### DIFF
--- a/KeePassFaviconDownloaderExt.cs
+++ b/KeePassFaviconDownloaderExt.cs
@@ -359,6 +359,15 @@ namespace KeePassFaviconDownloader
                 Uri nextUri = fullURI;
                 do
                 {
+                	// Some site needs a CookieContainer so that a now empty page is returned
+                    //  try "http://www.prettygreen.com/"
+                    hw.PreRequest += request =>
+                        {
+                            request.CookieContainer = new System.Net.CookieContainer();
+                            return true;
+                        };
+                    
+
                     // HtmlWeb.Load will follow 302 and 302 redirects to alternate URIs
                     hdoc = hw.Load(nextUri.AbsoluteUri);
                     responseURI = hw.ResponseUri;


### PR DESCRIPTION
HI Luckyrat,

Here is a patch that add a CookieContainer before retrieving URL. It seems that document could be empty for some URL if there is not a CookieContainer.

Try http://www.prettygreen.com/ for example.

I hope that it will be included in the next version.

Thanks,
incognito1234
